### PR TITLE
feat(backend-notification): implement pagination for notification endpoints

### DIFF
--- a/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/controller/NotificationController.java
+++ b/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/controller/NotificationController.java
@@ -19,12 +19,17 @@ public class NotificationController {
     private NotificationService service;
 
     @GetMapping("/notifications")
-    public ResponseEntity<List<Notification>> listNotifications(Authentication authentication) {
+    public ResponseEntity<Map<String, Object>> listNotifications(
+        Authentication authentication,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
         User authenticatedUser = (User) authentication.getPrincipal();
         int userId = authenticatedUser.getUser_id();
+
+        Map<String, Object> paginatedResponse = service.listByUserId(userId, page, size);
         
-        List<Notification> notifications = service.listByUserId(userId);
-        return ResponseEntity.ok(notifications);
+        return ResponseEntity.ok(paginatedResponse);
     }
 
     @PutMapping("/notifications/{id}/read")

--- a/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/repository/NotificationRepository.java
+++ b/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/repository/NotificationRepository.java
@@ -31,11 +31,17 @@ public class NotificationRepository {
         jdbcTemplate.update(sql, userId, reportId, message);
         
         return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Integer.class);
-    }   
+    }
 
-    public List<Notification> getNotificationsByUserId(int userId) {
-        String sql = "SELECT * FROM notifications WHERE user_id = ? ORDER BY created_at DESC";
-        return jdbcTemplate.query(sql, notificationMapper, userId);
+    public List<Notification> getNotificationsByUserId(int userId, int limit, int offset) {
+        String sql = "SELECT * FROM notifications WHERE user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?";
+        return jdbcTemplate.query(sql, notificationMapper, userId, limit, offset);
+    }
+
+    public int countNotificationsByUserId(int userId) {
+        String sql = "SELECT COUNT(*) FROM notifications WHERE user_id = ?";
+        Integer count = jdbcTemplate.queryForObject(sql, Integer.class, userId);
+        return (count != null) ? count : 0;
     }
 
     public boolean markAsRead(int notifId) {

--- a/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/service/NotificationService.java
+++ b/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/service/NotificationService.java
@@ -23,8 +23,21 @@ public class NotificationService {
         );
     }
 
-    public List<Notification> listByUserId(int userId) {
-        return repo.getNotificationsByUserId(userId);
+    public Map<String, Object> listByUserId(int userId, int page, int size) {
+        int offset = (page - 1) * size;
+
+        List<Notification> notifications = repo.getNotificationsByUserId(userId, size, offset);
+
+        int totalItems = repo.countNotificationsByUserId(userId);
+
+        int totalPages = (int) Math.ceil((double) totalItems / size);
+
+        return Map.of(
+            "items", notifications,
+            "currentPage", page,
+            "totalPages", totalPages,
+            "totalItems", totalItems
+        );
     }
 
     public boolean markAsRead(int notifId) {


### PR DESCRIPTION
Refactors the notification system to support server-side pagination. This prevents fetching all notifications at once, which was a major performance bottleneck.

- NotificationController: Updated to accept 'page' and 'size' query params.
- NotificationService: Now calculates offset, totalPages, and returns a paginated Map<> object.
- NotificationRepository: Updated SQL to use LIMIT/OFFSET and added a new countNotificationsByUserId() method.