### PR TITLE
refactor(backend-notification): Standardize notification output using DTO

### DIFF
--- a/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/dto/NotificationResponseDTO.java
+++ b/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/dto/NotificationResponseDTO.java
@@ -1,0 +1,25 @@
+package com.recorever.recorever_backend.dto;
+
+import com.recorever.recorever_backend.model.Notification;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class NotificationResponseDTO {
+    private int notif_id;
+    private int report_id;
+    private String message;
+    private String status; // 'unread' or 'read'
+    private String created_at;
+
+    public static NotificationResponseDTO from(Notification notification) {
+        NotificationResponseDTO dto = new NotificationResponseDTO();
+        dto.setNotif_id(notification.getNotif_id());
+        dto.setReport_id(notification.getReport_id());
+        dto.setMessage(notification.getMessage());
+        dto.setStatus(notification.getStatus());
+        dto.setCreated_at(notification.getCreated_at());
+        return dto;
+    }
+}

--- a/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/service/NotificationService.java
+++ b/backend/recorever-backend/src/main/java/com/recorever/recorever_backend/service/NotificationService.java
@@ -1,12 +1,14 @@
 package com.recorever.recorever_backend.service;
 
 import com.recorever.recorever_backend.model.Notification;
+import com.recorever.recorever_backend.dto.NotificationResponseDTO;
 import com.recorever.recorever_backend.repository.NotificationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class NotificationService {
@@ -28,12 +30,16 @@ public class NotificationService {
 
         List<Notification> notifications = repo.getNotificationsByUserId(userId, size, offset);
 
+        List<NotificationResponseDTO> dtos = notifications.stream()
+            .map(NotificationResponseDTO::from)
+            .collect(Collectors.toList());
+
         int totalItems = repo.countNotificationsByUserId(userId);
 
         int totalPages = (int) Math.ceil((double) totalItems / size);
 
         return Map.of(
-            "items", notifications,
+            "items", dtos, // Return the list of DTOs
             "currentPage", page,
             "totalPages", totalPages,
             "totalItems", totalItems


### PR DESCRIPTION
Introduce NotificationResponseDTO and refactor NotificationService to use it when returning lists of notifications.

This ensures:
* **Output Standardization:** Decouples the API response from the internal Notification model.
* **Controlled Output:** Allows explicit control over fields exposed to the frontend.