### PR TITLE
refactor(frontend-profile): remove Claim Items tab and related logic

### DIFF
--- a/frontend/recorever-frontend/src/app/page/user/profile-page/profile-page.html
+++ b/frontend/recorever-frontend/src/app/page/user/profile-page/profile-page.html
@@ -61,13 +61,6 @@
                   (click)="setActiveTab('lost')">
         Lost
       </button>
-      <button type="button"
-          class="profile-page__tab-btn"
-          [class.profile-page__tab-btn--active]=
-            "(activeTab$ | async) === 'claim'"
-                (click)="setActiveTab('claim')">
-        Claim Items
-      </button>
     </div>
 
     <div class="profile-page__filter">

--- a/frontend/recorever-frontend/src/app/page/user/profile-page/profile-page.ts
+++ b/frontend/recorever-frontend/src/app/page/user/profile-page/profile-page.ts
@@ -11,13 +11,11 @@ import { CodesModal } from '../../../modal/codes-modal/codes-modal';
 
 import { ItemService } from '../../../core/services/item-service';
 import { UserService } from '../../../core/services/user-service';
-import { ClaimService } from '../../../core/services/claim-service';
 
 import { Report } from '../../../models/item-model';
 import { User } from '../../../models/user-model';
-import { Claim } from '../../../models/claim-model';
 
-type TabType = 'all' | 'found' | 'lost' | 'claim';
+type TabType = 'all' | 'found' | 'lost';
 
 @Component({
   selector: 'app-profile-page',
@@ -35,7 +33,6 @@ type TabType = 'all' | 'found' | 'lost' | 'claim';
 export class ProfilePage implements OnInit {
   private itemService = inject(ItemService);
   private userService = inject(UserService);
-  private claimService = inject(ClaimService);
 
   activeTab$ = new BehaviorSubject<TabType>('all');
   activeStatus$ = new BehaviorSubject<string>('');
@@ -56,9 +53,6 @@ export class ProfilePage implements OnInit {
     const item = this.viewCodeItem();
     if (!item) return '';
 
-    if (item.claim_code || item.type === 'lost') {
-      return 'Ticket ID';
-    }
     return 'Reference Code';
   });
 
@@ -68,10 +62,6 @@ export class ProfilePage implements OnInit {
 
     if (item.type === 'lost') {
       return 'Pending';
-    }
-
-    if (item.claim_code) {
-      return item.claim_code || 'N/A';
     }
 
     return item.surrender_code || 'N/A';
@@ -124,25 +114,6 @@ export class ProfilePage implements OnInit {
   ): Observable<Report[]> {
     let source$: Observable<Report[]>;
 
-    if (tab === 'claim') {
-      return this.claimService.getMyClaims(userId).pipe(
-        map((claims: Claim[]) => {
-          return claims.map((c) => ({
-            report_id: c.report_id,
-            user_id: c.user_id,
-            type: 'found',
-            item_name: c.item_name || 'Claimed Item',
-            location: 'See Details',
-            date_reported: c.created_at,
-            date_resolved: null,
-            description: c.admin_remarks || '',
-            status: c.status as any,
-            surrender_code: null,
-            claim_code: c.claim_code || null
-          } as Report));
-        })
-      );
-    }
 
     if (tab === 'all') {
       source$ = combineLatest([


### PR DESCRIPTION
- Removed the "Claim Items" tab button from profile-page.html
- Removed ClaimService dependency and imports from profile-page.ts
- Deleted 'claim' case logic in fetchReportsByTab
- Updated TabType definition to exclude 'claim'