### PR TITLE
feat(frontend-report-card): implement status-based edit locking with tooltip feedback

### DIFF
--- a/frontend/recorever-frontend/src/app/share-ui-blocks/report-item-grid/report-item-card/report-item-card.html
+++ b/frontend/recorever-frontend/src/app/share-ui-blocks/report-item-grid/report-item-card/report-item-card.html
@@ -50,7 +50,13 @@
           </button>
         }
         @if (isOwner()) {
-          <button mat-menu-item (click)="onEdit($event)">
+          <button 
+            mat-menu-item 
+            (click)="onEdit($event)"
+            [disabled]="!isEditable()"
+            [matTooltip]="!isEditable()
+                ? 'Verified reports are locked and cannot be edited' : ''"
+            matTooltipPosition="left">
             <mat-icon>edit_square</mat-icon>
             <span>Edit Report</span>
           </button>

--- a/frontend/recorever-frontend/src/app/share-ui-blocks/report-item-grid/report-item-card/report-item-card.ts
+++ b/frontend/recorever-frontend/src/app/share-ui-blocks/report-item-grid/report-item-card/report-item-card.ts
@@ -15,6 +15,7 @@ import type { Report } from '../../../models/item-model';
 import { ItemStatus } from '../../status-badge/status-badge';
 import { StatusBadge } from '../../status-badge/status-badge';
 import { TimeAgoPipe } from '../../../pipes/time-ago.pipe';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-report-item-card',
@@ -29,6 +30,7 @@ import { TimeAgoPipe } from '../../../pipes/time-ago.pipe';
     MatDividerModule,
     StatusBadge,
     TimeAgoPipe,
+    MatTooltipModule,
   ],
   templateUrl: './report-item-card.html',
   styleUrls: ['./report-item-card.scss'],
@@ -86,6 +88,11 @@ export class ReportItemCard {
 
   isOwner = computed((): boolean => {
     return this.currentUserId() === this.report().user_id;
+  });
+
+  isEditable = computed((): boolean => {
+    const status = this.report().status;
+    return status === 'pending';
   });
 
   getCodeButtonLabel(): string {


### PR DESCRIPTION
This PR implements a lock mechanism for reports within the `ReportItemCard`. It prevents users from editing reports that have already been verified or processed.