### PR TITLE
feat(frontend-claim-btn): apply reference code access to the report detail modal

### DIFF
--- a/frontend/recorever-frontend/src/app/modal/report-detail-modal/report-detail-modal.html
+++ b/frontend/recorever-frontend/src/app/modal/report-detail-modal/report-detail-modal.html
@@ -67,6 +67,16 @@
             </div>
           }
         </div>
+
+        @if (report.type === 'found') {
+          <button 
+            type="button" 
+            class="view-ticket-btn"
+            (click)="onTicketClick(); $event.stopPropagation()">
+            {{ getCodeButtonLabel() }}
+            <span class="material-icons">keyboard_arrow_right</span>
+          </button>
+        }
       </div>
 
       @if (submissionError()) {

--- a/frontend/recorever-frontend/src/app/modal/report-detail-modal/report-detail-modal.ts
+++ b/frontend/recorever-frontend/src/app/modal/report-detail-modal/report-detail-modal.ts
@@ -125,6 +125,18 @@ export class ReportDetailModal implements OnInit {
       .subscribe();
   }
 
+  protected getCodeButtonLabel(): string {
+    return (this.report.type === 'lost' || this.report.claim_code)
+      ? 'View Ticket ID'
+      : 'View Reference Code';
+  }
+
+  protected onTicketClick(): void {
+    if (this.report.claim_code || this.report.surrender_code) {
+      this.statusUpdated.emit(this.report);
+    }
+  }
+
   protected onClose(): void {
     this.close.emit();
   }


### PR DESCRIPTION
This PR ports the existing **Ticket ID / Reference Code** logic from the report cards into the `ItemDetailModal`.