### PR TITLE
style(frontend-description): limit description to 3 lines with scroll for overflow

### DIFF
--- a/frontend/recorever-frontend/src/app/modal/item-detail-modal/item-detail-modal.scss
+++ b/frontend/recorever-frontend/src/app/modal/item-detail-modal/item-detail-modal.scss
@@ -246,6 +246,10 @@ $text-secondary: #8e8e93;
       color: $text-main;
       line-height: 1.4;
       font-size: 13px;
+      max-height: calc(1.4em * 2); 
+      overflow-y: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
     }
   }
 }


### PR DESCRIPTION
This update maintains a uniform grid layout and prevents extremely long text from distorting the report cards. The description is now limited to a maximum of three lines.