### PR TITLE
fix(frontend-header): guard notification component behind auth state

### DIFF
--- a/frontend/recorever-frontend/src/app/share-ui-blocks/header/header.html
+++ b/frontend/recorever-frontend/src/app/share-ui-blocks/header/header.html
@@ -40,7 +40,7 @@
   </div>
   }
 
-  @if (!showButtons) {
+  @if (isLoggedIn) {
     <div class="user-info">
       <div class="mobile-notification-wrapper">
         <app-notification></app-notification>

--- a/frontend/recorever-frontend/src/app/share-ui-blocks/header/header.ts
+++ b/frontend/recorever-frontend/src/app/share-ui-blocks/header/header.ts
@@ -4,6 +4,7 @@ import { RouterModule, Router, RouteReuseStrategy } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { Notification } from '../notification/notification';
+import { AuthService } from '../../core/auth/auth-service';
 
 @Component({
   selector: 'app-header',
@@ -25,11 +26,18 @@ export class Header {
 
   @Output() menuToggled = new EventEmitter<void>();
 
+  isLoggedIn = false;
+
   constructor(
+    private authService: AuthService,
     private router: Router,
     private routeReuseStrategy: RouteReuseStrategy,
     private scroller: ViewportScroller
   ) {}
+
+  ngOnInit(): void {
+    this.isLoggedIn = this.authService.isLoggedIn();
+  }
 
   public toggleMenu(): void {
     this.menuToggled.emit();


### PR DESCRIPTION
Use auth state in header to prevent notification component
from mounting when logged out, eliminating unwanted API requests.